### PR TITLE
docs: data-driven system-catalog reference, phase 3 (document mz_introspection per_worker variants)

### DIFF
--- a/ci/test/gen-per-worker-variants.py
+++ b/ci/test/gen-per-worker-variants.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Adds `per_worker` variants (Task 1's refined shape: a full catalog-sourced
+column list, no meanings) to documented parent relations, sourced from the
+live catalog rather than hand-invented.
+"""
+
+import re
+
+PER_WORKER_SUFFIX = "_per_worker"
+COMPUTE_PREFIX = "mz_compute_"
+MZ_PREFIX = "mz_"
+
+
+def parent_of(name: str, documented: set[str]) -> str | None:
+    """Resolve a `_per_worker` relation name to its documented parent's name,
+    or `None` if no documented parent exists (an orphan).
+
+    The parent is usually the name with the `_per_worker` suffix stripped.
+    A handful of per-worker relations additionally carry a `mz_compute_`
+    prefix that their (older) global view lacks, e.g.
+    `mz_compute_lir_mapping_per_worker` -> `mz_lir_mapping`; that alias is
+    tried second.
+    """
+    if not name.endswith(PER_WORKER_SUFFIX):
+        return None
+    base = name[: -len(PER_WORKER_SUFFIX)]
+    if base in documented:
+        return base
+    if base.startswith(COMPUTE_PREFIX):
+        aliased = MZ_PREFIX + base[len(COMPUTE_PREFIX) :]
+        if aliased in documented:
+            return aliased
+    return None
+
+
+def add_variants(
+    ydoc: dict, md: str, catalog_columns: dict[str, list[dict]]
+) -> tuple[dict, str]:
+    """Add a `per_worker` variant entry to each parent relation in `ydoc` for
+    every `*_per_worker` relation in `catalog_columns`, and strip the
+    corresponding `RELATION_SPEC_UNDOCUMENTED` marker from `md`.
+
+    Per-worker relations with no documented parent (orphans) are left
+    untouched: their marker stays in `md` for a later phase to pick up.
+    Relations that already have a variant of that name (e.g.
+    `mz_active_peeks_per_worker`, added by hand before this generator
+    existed) are skipped so the variant is not duplicated.
+    """
+    relations_by_name = {r["name"]: r for r in ydoc["relations"]}
+    documented = set(relations_by_name)
+
+    for pw_name, columns in catalog_columns.items():
+        if not pw_name.endswith(PER_WORKER_SUFFIX):
+            continue
+        parent = parent_of(pw_name, documented)
+        if parent is None:
+            continue
+        relation = relations_by_name[parent]
+        variants = relation.setdefault("variants", [])
+        if any(v["name"] == pw_name for v in variants):
+            continue
+        variants.append(
+            {
+                "name": pw_name,
+                "kind": "per_worker",
+                "description": (
+                    f"The same data as `{parent}`, but reported per Timely "
+                    "Dataflow worker."
+                ),
+                "columns": columns,
+            }
+        )
+        marker = f"<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.{pw_name} -->"
+        md = re.sub(rf"{re.escape(marker)}\n?", "", md)
+
+    return ydoc, md
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    import yaml
+
+    md_path = sys.argv[
+        1
+    ]  # e.g. doc/user/content/reference/system-catalog/mz_introspection.md
+    tsv_path = sys.argv[2]  # relation<TAB>column<TAB>type, position order
+
+    md_text = open(md_path, encoding="utf-8").read()
+
+    schema_name = os.path.splitext(os.path.basename(md_path))[0]
+    data_path = os.path.join("doc", "user", "data", f"{schema_name}.yml")
+    ydoc = yaml.safe_load(open(data_path, encoding="utf-8"))
+
+    catalog_columns: dict[str, list[dict]] = {}
+    with open(tsv_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.rstrip("\n")
+            if not line:
+                continue
+            relation, column, type_ = line.split("\t")
+            catalog_columns.setdefault(relation, []).append(
+                {"name": column, "type": type_}
+            )
+
+    ydoc, md_text = add_variants(ydoc, md_text, catalog_columns)
+
+    with open(data_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(ydoc, f, sort_keys=False, allow_unicode=True, width=10_000)
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write(md_text)
+
+    print(f"updated {data_path} and {md_path}")

--- a/ci/test/gen-per-worker-variants.py
+++ b/ci/test/gen-per-worker-variants.py
@@ -73,15 +73,23 @@ def add_variants(
             {
                 "name": pw_name,
                 "kind": "per_worker",
-                "description": (
-                    f"The same data as `{parent}`, but reported per Timely "
-                    "Dataflow worker."
-                ),
+                "description": f"The per-worker data underlying `{parent}`.",
                 "columns": columns,
             }
         )
         marker = f"<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.{pw_name} -->"
-        md = re.sub(rf"{re.escape(marker)}\n?", "", md)
+        marker_re = re.escape(marker)
+        # A marker line sitting alone between two blank lines (the common
+        # case) leaves a doubled blank line if we only drop the marker
+        # itself, so consume one of the surrounding blank lines too. A
+        # marker that instead sits next to sibling markers, with no blank
+        # line between them, is removed on its own: its neighbors already
+        # supply the correct blank-line spacing.
+        md = re.sub(
+            rf"(?<=\n)\n{marker_re}\n(?=\n)|{marker_re}\n?",
+            "",
+            md,
+        )
 
     return ydoc, md
 

--- a/ci/test/lint-docs-catalog.py
+++ b/ci/test/lint-docs-catalog.py
@@ -149,11 +149,14 @@ def emit_from_yaml(schema: str, object_name: str, objects: list, schemas: set) -
             # Existence only: no column table to check, the relation is recorded
             # above so the completeness query still covers it.
             continue
-        # per_worker (and any future non-raw variant): base columns plus the
-        # variant's extra columns, checked columns-and-types only. Ordered by
-        # name because the catalog column position of worker_id is not fixed.
-        columns = list(relation["columns"]) + list(variant.get("columns", []))
-        columns.sort(key=lambda c: c["name"])
+        # per_worker (and any future non-raw variant): the variant's own full
+        # column list, checked columns-and-types only. A variant is not
+        # merely the base columns plus extras: an aggregating global view can
+        # change column types (e.g. a `count` that is `numeric` in the global
+        # view is `bigint` per worker), so the variant carries its own
+        # complete list. Ordered by name because catalog column position for
+        # a variant is not guaranteed to match the base relation's.
+        columns = sorted(variant.get("columns", []), key=lambda c: c["name"])
         print("query TT")
         print(
             f"SELECT name, type FROM objects WHERE schema = '{schema}' AND object = '{variant['name']}' ORDER BY name"

--- a/ci/test/test_gen_per_worker_variants.py
+++ b/ci/test/test_gen_per_worker_variants.py
@@ -1,0 +1,62 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import importlib.util
+import pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    "gen_per_worker_variants",
+    pathlib.Path(__file__).parent / "gen-per-worker-variants.py",
+)
+gen = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen)
+
+
+def test_parent_of_direct_and_alias():
+    docd = {"mz_dataflows", "mz_dataflow_global_ids", "mz_lir_mapping"}
+    assert gen.parent_of("mz_dataflows_per_worker", docd) == "mz_dataflows"
+    assert (
+        gen.parent_of("mz_compute_dataflow_global_ids_per_worker", docd)
+        == "mz_dataflow_global_ids"
+    )
+    assert gen.parent_of("mz_compute_lir_mapping_per_worker", docd) == "mz_lir_mapping"
+    assert gen.parent_of("mz_orphan_per_worker", docd) is None
+
+
+def test_add_variants_injects_and_removes_marker():
+    ydoc = {
+        "relations": [
+            {
+                "name": "mz_dataflows",
+                "description": "d",
+                "columns": [{"name": "id", "type": "uint8"}],
+            }
+        ]
+    }
+    md = (
+        "## `mz_dataflows`\n\n"
+        "<!-- RELATION_SPEC mz_introspection.mz_dataflows FROM_YAML -->\n"
+        '{{< catalog-relation schema="mz_introspection" name="mz_dataflows" >}}\n\n'
+        "<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflows_per_worker -->\n"
+    )
+    catalog = {
+        "mz_dataflows_per_worker": [
+            {"name": "id", "type": "uint8"},
+            {"name": "worker_id", "type": "uint8"},
+            {"name": "name", "type": "text"},
+        ]
+    }
+    ydoc2, md2 = gen.add_variants(ydoc, md, catalog)
+    rel = ydoc2["relations"][0]
+    assert rel["variants"][0]["name"] == "mz_dataflows_per_worker"
+    assert rel["variants"][0]["kind"] == "per_worker"
+    assert rel["variants"][0]["columns"] == catalog["mz_dataflows_per_worker"]
+    assert (
+        "RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflows_per_worker" not in md2
+    )

--- a/ci/test/test_gen_per_worker_variants.py
+++ b/ci/test/test_gen_per_worker_variants.py
@@ -60,3 +60,76 @@ def test_add_variants_injects_and_removes_marker():
     assert (
         "RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflows_per_worker" not in md2
     )
+
+
+def test_add_variants_skips_existing_variant():
+    """A per_worker relation that already has a hand-authored variant on its
+    parent (e.g. mz_active_peeks_per_worker, added before this generator
+    existed) must not be duplicated.
+    """
+    existing_variant = {
+        "name": "mz_dataflows_per_worker",
+        "kind": "per_worker",
+        "description": "hand-authored, pre-existing",
+        "columns": [{"name": "id", "type": "uint8"}],
+    }
+    ydoc = {
+        "relations": [
+            {
+                "name": "mz_dataflows",
+                "description": "d",
+                "columns": [{"name": "id", "type": "uint8"}],
+                "variants": [existing_variant],
+            }
+        ]
+    }
+    md = (
+        "## `mz_dataflows`\n\n"
+        "<!-- RELATION_SPEC mz_introspection.mz_dataflows FROM_YAML -->\n"
+        '{{< catalog-relation schema="mz_introspection" name="mz_dataflows" >}}\n\n'
+        "<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflows_per_worker -->\n"
+    )
+    catalog = {
+        "mz_dataflows_per_worker": [
+            {"name": "id", "type": "uint8"},
+            {"name": "worker_id", "type": "uint8"},
+        ]
+    }
+    ydoc2, md2 = gen.add_variants(ydoc, md, catalog)
+    rel = ydoc2["relations"][0]
+    # No duplicate variant was appended, and the existing one is untouched.
+    assert rel["variants"] == [existing_variant]
+    # The marker removal is gated on the append actually happening, so a
+    # skipped (already-present) variant leaves its marker in place too.
+    assert "RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflows_per_worker" in md2
+
+
+def test_add_variants_skips_orphan():
+    """A `_per_worker` relation with no documented parent (an orphan) is left
+    untouched: no variant is added anywhere, and its
+    RELATION_SPEC_UNDOCUMENTED marker stays in the md for a later phase.
+    """
+    ydoc = {
+        "relations": [
+            {
+                "name": "mz_dataflows",
+                "description": "d",
+                "columns": [{"name": "id", "type": "uint8"}],
+            }
+        ]
+    }
+    md = (
+        "## `mz_dataflows`\n\n"
+        "<!-- RELATION_SPEC mz_introspection.mz_dataflows FROM_YAML -->\n"
+        '{{< catalog-relation schema="mz_introspection" name="mz_dataflows" >}}\n\n'
+        "<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_orphan_per_worker -->\n"
+    )
+    catalog = {
+        "mz_orphan_per_worker": [
+            {"name": "id", "type": "uint8"},
+            {"name": "worker_id", "type": "uint8"},
+        ]
+    }
+    ydoc2, md2 = gen.add_variants(ydoc, md, catalog)
+    assert "variants" not in ydoc2["relations"][0]
+    assert "RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_orphan_per_worker" in md2

--- a/doc/user/content/reference/system-catalog/mz_introspection.md
+++ b/doc/user/content/reference/system-catalog/mz_introspection.md
@@ -69,18 +69,15 @@ Per-worker relations expose the same data as their global counterparts, but have
 <!-- RELATION_SPEC mz_introspection.mz_compute_exports FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_exports" >}}
 
-
 ## `mz_compute_frontiers`
 
 <!-- RELATION_SPEC mz_introspection.mz_compute_frontiers FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_frontiers" >}}
 
-
 ## `mz_compute_import_frontiers`
 
 <!-- RELATION_SPEC mz_introspection.mz_compute_import_frontiers FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_import_frontiers" >}}
-
 
 ## `mz_compute_operator_durations_histogram`
 
@@ -111,12 +108,10 @@ Summaries are flattened into separate quantile, sum, and count rows.
 <!-- RELATION_SPEC mz_introspection.mz_dataflows FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflows" >}}
 
-
 ## `mz_dataflow_addresses`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_addresses FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_addresses" >}}
-
 
 ## `mz_dataflow_arrangement_sizes`
 
@@ -128,36 +123,30 @@ Summaries are flattened into separate quantile, sum, and count rows.
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_channels FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_channels" >}}
 
-
 ## `mz_dataflow_channel_operators`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_channel_operators FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_channel_operators" >}}
-
 
 ## `mz_dataflow_global_ids`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_global_ids FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_global_ids" >}}
 
-
 ## `mz_dataflow_operators`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_operators FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_operators" >}}
-
 
 ## `mz_dataflow_operator_dataflows`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_operator_dataflows FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_operator_dataflows" >}}
 
-
 ## `mz_dataflow_operator_parents`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_operator_parents FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_operator_parents" >}}
-
 
 ## `mz_expected_group_size_advice`
 
@@ -175,7 +164,6 @@ See [Which part of my query runs slowly or uses a lot of memory?](/transform-dat
 
 <!-- RELATION_SPEC mz_introspection.mz_lir_mapping FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_lir_mapping" >}}
-
 
 ## `mz_message_counts`
 
@@ -199,12 +187,10 @@ See [Which part of my query runs slowly or uses a lot of memory?](/transform-dat
 <!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_records_per_dataflow" >}}
 
-
 ## `mz_records_per_dataflow_operator`
 
 <!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow_operator FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_records_per_dataflow_operator" >}}
-
 
 ## `mz_scheduling_elapsed`
 

--- a/doc/user/content/reference/system-catalog/mz_introspection.md
+++ b/doc/user/content/reference/system-catalog/mz_introspection.md
@@ -40,7 +40,6 @@ Per-worker relations expose the same data as their global counterparts, but have
 <!-- RELATION_SPEC mz_introspection.mz_arrangement_sharing FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_arrangement_sharing" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sharing_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sharing_raw -->
 
 ## `mz_arrangement_sizes`
@@ -48,7 +47,6 @@ Per-worker relations expose the same data as their global counterparts, but have
 <!-- RELATION_SPEC mz_introspection.mz_arrangement_sizes FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_arrangement_sizes" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sizes_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_records_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_batcher_allocations_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_batcher_capacity_raw -->
@@ -64,7 +62,6 @@ Per-worker relations expose the same data as their global counterparts, but have
 <!-- RELATION_SPEC mz_introspection.mz_compute_error_counts FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_error_counts" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_error_counts_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_error_counts_raw -->
 
 ## `mz_compute_exports`
@@ -72,28 +69,24 @@ Per-worker relations expose the same data as their global counterparts, but have
 <!-- RELATION_SPEC mz_introspection.mz_compute_exports FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_exports" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_exports_per_worker -->
 
 ## `mz_compute_frontiers`
 
 <!-- RELATION_SPEC mz_introspection.mz_compute_frontiers FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_frontiers" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_frontiers_per_worker -->
 
 ## `mz_compute_import_frontiers`
 
 <!-- RELATION_SPEC mz_introspection.mz_compute_import_frontiers FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_import_frontiers" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_import_frontiers_per_worker -->
 
 ## `mz_compute_operator_durations_histogram`
 
 <!-- RELATION_SPEC mz_introspection.mz_compute_operator_durations_histogram FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_operator_durations_histogram" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_operator_durations_histogram_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_operator_durations_histogram_raw -->
 
 ## `mz_cluster_prometheus_metrics`
@@ -118,14 +111,12 @@ Summaries are flattened into separate quantile, sum, and count rows.
 <!-- RELATION_SPEC mz_introspection.mz_dataflows FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflows" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflows_per_worker -->
 
 ## `mz_dataflow_addresses`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_addresses FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_addresses" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_addresses_per_worker -->
 
 ## `mz_dataflow_arrangement_sizes`
 
@@ -137,42 +128,36 @@ Summaries are flattened into separate quantile, sum, and count rows.
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_channels FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_channels" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_channels_per_worker -->
 
 ## `mz_dataflow_channel_operators`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_channel_operators FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_channel_operators" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_channel_operators_per_worker -->
 
 ## `mz_dataflow_global_ids`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_global_ids FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_global_ids" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_dataflow_global_ids_per_worker -->
 
 ## `mz_dataflow_operators`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_operators FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_operators" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_operators_per_worker -->
 
 ## `mz_dataflow_operator_dataflows`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_operator_dataflows FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_operator_dataflows" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_operator_dataflows_per_worker -->
 
 ## `mz_dataflow_operator_parents`
 
 <!-- RELATION_SPEC mz_introspection.mz_dataflow_operator_parents FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_dataflow_operator_parents" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_dataflow_operator_parents_per_worker -->
 
 ## `mz_expected_group_size_advice`
 
@@ -191,14 +176,12 @@ See [Which part of my query runs slowly or uses a lot of memory?](/transform-dat
 <!-- RELATION_SPEC mz_introspection.mz_lir_mapping FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_lir_mapping" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_lir_mapping_per_worker -->
 
 ## `mz_message_counts`
 
 <!-- RELATION_SPEC mz_introspection.mz_message_counts FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_message_counts" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_counts_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_batch_counts_received_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_batch_counts_sent_raw -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_counts_received_raw -->
@@ -209,7 +192,6 @@ See [Which part of my query runs slowly or uses a lot of memory?](/transform-dat
 <!-- RELATION_SPEC mz_introspection.mz_peek_durations_histogram FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_peek_durations_histogram" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_peek_durations_histogram_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_peek_durations_histogram_raw -->
 
 ## `mz_records_per_dataflow`
@@ -217,21 +199,18 @@ See [Which part of my query runs slowly or uses a lot of memory?](/transform-dat
 <!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_records_per_dataflow" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_records_per_dataflow_per_worker -->
 
 ## `mz_records_per_dataflow_operator`
 
 <!-- RELATION_SPEC mz_introspection.mz_records_per_dataflow_operator FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_records_per_dataflow_operator" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_records_per_dataflow_operator_per_worker -->
 
 ## `mz_scheduling_elapsed`
 
 <!-- RELATION_SPEC mz_introspection.mz_scheduling_elapsed FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_scheduling_elapsed" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_elapsed_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_elapsed_raw -->
 
 ## `mz_scheduling_parks_histogram`
@@ -239,7 +218,6 @@ See [Which part of my query runs slowly or uses a lot of memory?](/transform-dat
 <!-- RELATION_SPEC mz_introspection.mz_scheduling_parks_histogram FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_scheduling_parks_histogram" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_parks_histogram_per_worker -->
 <!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_parks_histogram_raw -->
 
 [`bigint`]: /sql/types/bigint

--- a/doc/user/data/mz_introspection.yml
+++ b/doc/user/data/mz_introspection.yml
@@ -19,13 +19,19 @@ relations:
   variants:
   - name: mz_active_peeks_per_worker
     kind: per_worker
-    description: 'The same data as `mz_active_peeks`, but split by Timely Dataflow worker.
-
-      '
+    description: |
+      The same data as `mz_active_peeks`, but reported per Timely Dataflow worker.
     columns:
+    - name: id
+      type: uuid
     - name: worker_id
       type: uint8
-      meaning: The ID of the Timely Dataflow worker.
+    - name: object_id
+      type: text
+    - name: type
+      type: text
+    - name: time
+      type: mz_timestamp
 - name: mz_arrangement_sharing
   description: The `mz_arrangement_sharing` view describes how many times each [arrangement](/get-started/arrangements/#arrangements) in the system is used.
   columns:

--- a/doc/user/data/mz_introspection.yml
+++ b/doc/user/data/mz_introspection.yml
@@ -19,8 +19,9 @@ relations:
   variants:
   - name: mz_active_peeks_per_worker
     kind: per_worker
-    description: |
-      The same data as `mz_active_peeks`, but reported per Timely Dataflow worker.
+    description: 'The same data as `mz_active_peeks`, but reported per Timely Dataflow worker.
+
+      '
     columns:
     - name: id
       type: uuid
@@ -41,6 +42,17 @@ relations:
   - name: count
     type: bigint
     meaning: The number of operators that share the arrangement.
+  variants:
+  - name: mz_arrangement_sharing_per_worker
+    kind: per_worker
+    description: The same data as `mz_arrangement_sharing`, but reported per Timely Dataflow worker.
+    columns:
+    - name: operator_id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: count
+      type: bigint
 - name: mz_arrangement_sizes
   description: 'The `mz_arrangement_sizes` view describes the size of each [arrangement](/get-started/arrangements/#arrangements) in the system.
 
@@ -67,6 +79,25 @@ relations:
   - name: allocations
     type: bigint
     meaning: The number of separate memory allocations backing the arrangement.
+  variants:
+  - name: mz_arrangement_sizes_per_worker
+    kind: per_worker
+    description: The same data as `mz_arrangement_sizes`, but reported per Timely Dataflow worker.
+    columns:
+    - name: operator_id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: records
+      type: bigint
+    - name: batches
+      type: bigint
+    - name: size
+      type: bigint
+    - name: capacity
+      type: bigint
+    - name: allocations
+      type: bigint
 - name: mz_compute_error_counts
   description: 'The `mz_compute_error_counts` view describes the counts of errors in objects exported by [dataflows](/get-started/arrangements/#dataflows) in the system.
 
@@ -79,6 +110,17 @@ relations:
   - name: count
     type: numeric
     meaning: The count of errors present in this dataflow export.
+  variants:
+  - name: mz_compute_error_counts_per_worker
+    kind: per_worker
+    description: The same data as `mz_compute_error_counts`, but reported per Timely Dataflow worker.
+    columns:
+    - name: export_id
+      type: text
+    - name: worker_id
+      type: uint8
+    - name: count
+      type: bigint
 - name: mz_compute_exports
   description: The `mz_compute_exports` view describes the objects exported by [dataflows](/get-started/arrangements/#dataflows) in the system.
   columns:
@@ -88,6 +130,17 @@ relations:
   - name: dataflow_id
     type: uint8
     meaning: The ID of the dataflow. Corresponds to [`mz_dataflows.id`](#mz_dataflows).
+  variants:
+  - name: mz_compute_exports_per_worker
+    kind: per_worker
+    description: The same data as `mz_compute_exports`, but reported per Timely Dataflow worker.
+    columns:
+    - name: export_id
+      type: text
+    - name: worker_id
+      type: uint8
+    - name: dataflow_id
+      type: uint8
 - name: mz_compute_frontiers
   description: 'The `mz_compute_frontiers` view describes the frontier of each [dataflow](/get-started/arrangements/#dataflows) export in the system.
 
@@ -99,6 +152,17 @@ relations:
   - name: time
     type: mz_timestamp
     meaning: The next timestamp at which the dataflow output may change.
+  variants:
+  - name: mz_compute_frontiers_per_worker
+    kind: per_worker
+    description: The same data as `mz_compute_frontiers`, but reported per Timely Dataflow worker.
+    columns:
+    - name: export_id
+      type: text
+    - name: worker_id
+      type: uint8
+    - name: time
+      type: mz_timestamp
 - name: mz_compute_import_frontiers
   description: 'The `mz_compute_import_frontiers` view describes the frontiers of each [dataflow](/get-started/arrangements/#dataflows) import in the system.
 
@@ -113,6 +177,19 @@ relations:
   - name: time
     type: mz_timestamp
     meaning: The next timestamp at which the dataflow input may change.
+  variants:
+  - name: mz_compute_import_frontiers_per_worker
+    kind: per_worker
+    description: The same data as `mz_compute_import_frontiers`, but reported per Timely Dataflow worker.
+    columns:
+    - name: export_id
+      type: text
+    - name: import_id
+      type: text
+    - name: worker_id
+      type: uint8
+    - name: time
+      type: mz_timestamp
 - name: mz_compute_operator_durations_histogram
   description: The `mz_compute_operator_durations_histogram` view describes a histogram of the duration in nanoseconds of each invocation for each [dataflow](/get-started/arrangements/#dataflows) operator.
   columns:
@@ -125,6 +202,19 @@ relations:
   - name: count
     type: numeric
     meaning: The (noncumulative) count of invocations in the bucket.
+  variants:
+  - name: mz_compute_operator_durations_histogram_per_worker
+    kind: per_worker
+    description: The same data as `mz_compute_operator_durations_histogram`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: duration_ns
+      type: uint8
+    - name: count
+      type: bigint
 - name: mz_dataflows
   description: The `mz_dataflows` view describes the [dataflows](/get-started/arrangements/#dataflows) in the system.
   columns:
@@ -134,6 +224,17 @@ relations:
   - name: name
     type: text
     meaning: The internal name of the dataflow.
+  variants:
+  - name: mz_dataflows_per_worker
+    kind: per_worker
+    description: The same data as `mz_dataflows`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: name
+      type: text
 - name: mz_dataflow_addresses
   description: The `mz_dataflow_addresses` view describes how the [dataflow](/get-started/arrangements/#dataflows) channels and operators in the system are nested into scopes.
   columns:
@@ -143,6 +244,17 @@ relations:
   - name: address
     type: bigint list
     meaning: A list of scope-local indexes indicating the path from the root to this channel or operator.
+  variants:
+  - name: mz_dataflow_addresses_per_worker
+    kind: per_worker
+    description: The same data as `mz_dataflow_addresses`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: address
+      type: list
 - name: mz_dataflow_arrangement_sizes
   description: 'The `mz_dataflow_arrangement_sizes` view describes the size of arrangements per
 
@@ -192,6 +304,25 @@ relations:
   - name: type
     type: text
     meaning: The container type of the channel.
+  variants:
+  - name: mz_dataflow_channels_per_worker
+    kind: per_worker
+    description: The same data as `mz_dataflow_channels`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: from_index
+      type: uint8
+    - name: from_port
+      type: uint8
+    - name: to_index
+      type: uint8
+    - name: to_port
+      type: uint8
+    - name: type
+      type: text
 - name: mz_dataflow_channel_operators
   description: The `mz_dataflow_channel_operators` view associates [dataflow](/get-started/arrangements/#dataflows) channels with the operators that are their endpoints.
   columns:
@@ -213,6 +344,25 @@ relations:
   - name: type
     type: text
     meaning: The container type of the channel.
+  variants:
+  - name: mz_dataflow_channel_operators_per_worker
+    kind: per_worker
+    description: The same data as `mz_dataflow_channel_operators`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: from_operator_id
+      type: uint8
+    - name: from_operator_address
+      type: list
+    - name: to_operator_id
+      type: uint8
+    - name: to_operator_address
+      type: list
+    - name: type
+      type: text
 - name: mz_dataflow_global_ids
   description: The `mz_dataflow_global_ids` view associates [dataflow](/get-started/arrangements/#dataflows) ids with global ids (ids of the form `u8` or `t5`).
   columns:
@@ -222,6 +372,17 @@ relations:
   - name: global_id
     type: text
     meaning: A global ID associated with that dataflow.
+  variants:
+  - name: mz_compute_dataflow_global_ids_per_worker
+    kind: per_worker
+    description: The same data as `mz_dataflow_global_ids`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: global_id
+      type: text
 - name: mz_dataflow_operators
   description: The `mz_dataflow_operators` view describes the [dataflow](/get-started/arrangements/#dataflows) operators in the system.
   columns:
@@ -231,6 +392,17 @@ relations:
   - name: name
     type: text
     meaning: The internal name of the operator.
+  variants:
+  - name: mz_dataflow_operators_per_worker
+    kind: per_worker
+    description: The same data as `mz_dataflow_operators`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: name
+      type: text
 - name: mz_dataflow_operator_dataflows
   description: The `mz_dataflow_operator_dataflows` view describes the [dataflow](/get-started/arrangements/#dataflows) to which each operator belongs.
   columns:
@@ -246,6 +418,21 @@ relations:
   - name: dataflow_name
     type: text
     meaning: The internal name of the dataflow hosting the operator.
+  variants:
+  - name: mz_dataflow_operator_dataflows_per_worker
+    kind: per_worker
+    description: The same data as `mz_dataflow_operator_dataflows`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: name
+      type: text
+    - name: worker_id
+      type: uint8
+    - name: dataflow_id
+      type: uint8
+    - name: dataflow_name
+      type: text
 - name: mz_dataflow_operator_parents
   description: The `mz_dataflow_operator_parents` view describes how [dataflow](/get-started/arrangements/#dataflows) operators are nested into scopes, by relating operators to their parent operators.
   columns:
@@ -255,6 +442,17 @@ relations:
   - name: parent_id
     type: uint8
     meaning: The ID of the operator's parent operator. Corresponds to [`mz_dataflow_operators.id`](#mz_dataflow_operators).
+  variants:
+  - name: mz_dataflow_operator_parents_per_worker
+    kind: per_worker
+    description: The same data as `mz_dataflow_operator_parents`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: parent_id
+      type: uint8
+    - name: worker_id
+      type: uint8
 - name: mz_expected_group_size_advice
   description: 'The `mz_expected_group_size_advice` view provides advice on opportunities to set [query hints](/sql/select/#query-hints).
 
@@ -335,6 +533,27 @@ relations:
   - name: operator_id_end
     type: uint8
     meaning: The first dataflow operator ID _after_ this LIR operator (exclusive).
+  variants:
+  - name: mz_compute_lir_mapping_per_worker
+    kind: per_worker
+    description: The same data as `mz_lir_mapping`, but reported per Timely Dataflow worker.
+    columns:
+    - name: global_id
+      type: text
+    - name: lir_id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: operator
+      type: text
+    - name: parent_lir_id
+      type: uint8
+    - name: nesting
+      type: uint2
+    - name: operator_id_start
+      type: uint8
+    - name: operator_id_end
+      type: uint8
 - name: mz_message_counts
   description: 'The `mz_message_counts` view describes the messages and message batches sent and received over the [dataflow](/get-started/arrangements/#dataflows) channels in the system.
 
@@ -355,6 +574,25 @@ relations:
   - name: batch_received
     type: numeric
     meaning: The number of batches received.
+  variants:
+  - name: mz_message_counts_per_worker
+    kind: per_worker
+    description: The same data as `mz_message_counts`, but reported per Timely Dataflow worker.
+    columns:
+    - name: channel_id
+      type: uint8
+    - name: from_worker_id
+      type: uint8
+    - name: to_worker_id
+      type: uint8
+    - name: sent
+      type: bigint
+    - name: received
+      type: bigint
+    - name: batch_sent
+      type: bigint
+    - name: batch_received
+      type: bigint
 - name: mz_peek_durations_histogram
   description: The `mz_peek_durations_histogram` view describes a histogram of the duration in nanoseconds of read queries ("peeks") in the [dataflow](/get-started/arrangements/#dataflows) layer.
   columns:
@@ -367,6 +605,19 @@ relations:
   - name: count
     type: numeric
     meaning: The (noncumulative) count of peeks in this bucket.
+  variants:
+  - name: mz_peek_durations_histogram_per_worker
+    kind: per_worker
+    description: The same data as `mz_peek_durations_histogram`, but reported per Timely Dataflow worker.
+    columns:
+    - name: worker_id
+      type: uint8
+    - name: type
+      type: text
+    - name: duration_ns
+      type: uint8
+    - name: count
+      type: bigint
 - name: mz_records_per_dataflow
   description: The `mz_records_per_dataflow` view describes the number of records in each [dataflow](/get-started/arrangements/#dataflows).
   columns:
@@ -391,6 +642,27 @@ relations:
   - name: allocations
     type: bigint
     meaning: The number of separate memory allocations backing the arrangements.
+  variants:
+  - name: mz_records_per_dataflow_per_worker
+    kind: per_worker
+    description: The same data as `mz_records_per_dataflow`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: name
+      type: text
+    - name: worker_id
+      type: uint8
+    - name: records
+      type: bigint
+    - name: batches
+      type: bigint
+    - name: size
+      type: bigint
+    - name: capacity
+      type: bigint
+    - name: allocations
+      type: bigint
 - name: mz_records_per_dataflow_operator
   description: The `mz_records_per_dataflow_operator` view describes the number of records in each [dataflow](/get-started/arrangements/#dataflows) operator in the system.
   columns:
@@ -418,6 +690,29 @@ relations:
   - name: allocations
     type: bigint
     meaning: The number of separate memory allocations backing the arrangement.
+  variants:
+  - name: mz_records_per_dataflow_operator_per_worker
+    kind: per_worker
+    description: The same data as `mz_records_per_dataflow_operator`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: name
+      type: text
+    - name: worker_id
+      type: uint8
+    - name: dataflow_id
+      type: uint8
+    - name: records
+      type: bigint
+    - name: batches
+      type: bigint
+    - name: size
+      type: bigint
+    - name: capacity
+      type: bigint
+    - name: allocations
+      type: bigint
 - name: mz_scheduling_elapsed
   description: The `mz_scheduling_elapsed` view describes the total amount of time spent in each [dataflow](/get-started/arrangements/#dataflows) operator.
   columns:
@@ -427,6 +722,17 @@ relations:
   - name: elapsed_ns
     type: numeric
     meaning: The total elapsed time spent in the operator in nanoseconds.
+  variants:
+  - name: mz_scheduling_elapsed_per_worker
+    kind: per_worker
+    description: The same data as `mz_scheduling_elapsed`, but reported per Timely Dataflow worker.
+    columns:
+    - name: id
+      type: uint8
+    - name: worker_id
+      type: uint8
+    - name: elapsed_ns
+      type: bigint
 - name: mz_scheduling_parks_histogram
   description: The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow](/get-started/arrangements/#dataflows) worker park events. A park event occurs when a worker has no outstanding work.
   columns:
@@ -439,3 +745,16 @@ relations:
   - name: count
     type: numeric
     meaning: The (noncumulative) count of park events in this bucket.
+  variants:
+  - name: mz_scheduling_parks_histogram_per_worker
+    kind: per_worker
+    description: The same data as `mz_scheduling_parks_histogram`, but reported per Timely Dataflow worker.
+    columns:
+    - name: worker_id
+      type: uint8
+    - name: slept_for_ns
+      type: uint8
+    - name: requested_ns
+      type: uint8
+    - name: count
+      type: bigint

--- a/doc/user/data/mz_introspection.yml
+++ b/doc/user/data/mz_introspection.yml
@@ -19,9 +19,7 @@ relations:
   variants:
   - name: mz_active_peeks_per_worker
     kind: per_worker
-    description: 'The same data as `mz_active_peeks`, but reported per Timely Dataflow worker.
-
-      '
+    description: The per-worker data underlying `mz_active_peeks`.
     columns:
     - name: id
       type: uuid
@@ -45,7 +43,7 @@ relations:
   variants:
   - name: mz_arrangement_sharing_per_worker
     kind: per_worker
-    description: The same data as `mz_arrangement_sharing`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_arrangement_sharing`.
     columns:
     - name: operator_id
       type: uint8
@@ -82,7 +80,7 @@ relations:
   variants:
   - name: mz_arrangement_sizes_per_worker
     kind: per_worker
-    description: The same data as `mz_arrangement_sizes`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_arrangement_sizes`.
     columns:
     - name: operator_id
       type: uint8
@@ -113,7 +111,7 @@ relations:
   variants:
   - name: mz_compute_error_counts_per_worker
     kind: per_worker
-    description: The same data as `mz_compute_error_counts`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_compute_error_counts`.
     columns:
     - name: export_id
       type: text
@@ -133,7 +131,7 @@ relations:
   variants:
   - name: mz_compute_exports_per_worker
     kind: per_worker
-    description: The same data as `mz_compute_exports`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_compute_exports`.
     columns:
     - name: export_id
       type: text
@@ -155,7 +153,7 @@ relations:
   variants:
   - name: mz_compute_frontiers_per_worker
     kind: per_worker
-    description: The same data as `mz_compute_frontiers`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_compute_frontiers`.
     columns:
     - name: export_id
       type: text
@@ -180,7 +178,7 @@ relations:
   variants:
   - name: mz_compute_import_frontiers_per_worker
     kind: per_worker
-    description: The same data as `mz_compute_import_frontiers`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_compute_import_frontiers`.
     columns:
     - name: export_id
       type: text
@@ -205,7 +203,7 @@ relations:
   variants:
   - name: mz_compute_operator_durations_histogram_per_worker
     kind: per_worker
-    description: The same data as `mz_compute_operator_durations_histogram`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_compute_operator_durations_histogram`.
     columns:
     - name: id
       type: uint8
@@ -227,7 +225,7 @@ relations:
   variants:
   - name: mz_dataflows_per_worker
     kind: per_worker
-    description: The same data as `mz_dataflows`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_dataflows`.
     columns:
     - name: id
       type: uint8
@@ -247,7 +245,7 @@ relations:
   variants:
   - name: mz_dataflow_addresses_per_worker
     kind: per_worker
-    description: The same data as `mz_dataflow_addresses`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_dataflow_addresses`.
     columns:
     - name: id
       type: uint8
@@ -307,7 +305,7 @@ relations:
   variants:
   - name: mz_dataflow_channels_per_worker
     kind: per_worker
-    description: The same data as `mz_dataflow_channels`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_dataflow_channels`.
     columns:
     - name: id
       type: uint8
@@ -347,7 +345,7 @@ relations:
   variants:
   - name: mz_dataflow_channel_operators_per_worker
     kind: per_worker
-    description: The same data as `mz_dataflow_channel_operators`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_dataflow_channel_operators`.
     columns:
     - name: id
       type: uint8
@@ -375,7 +373,7 @@ relations:
   variants:
   - name: mz_compute_dataflow_global_ids_per_worker
     kind: per_worker
-    description: The same data as `mz_dataflow_global_ids`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_dataflow_global_ids`.
     columns:
     - name: id
       type: uint8
@@ -395,7 +393,7 @@ relations:
   variants:
   - name: mz_dataflow_operators_per_worker
     kind: per_worker
-    description: The same data as `mz_dataflow_operators`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_dataflow_operators`.
     columns:
     - name: id
       type: uint8
@@ -421,7 +419,7 @@ relations:
   variants:
   - name: mz_dataflow_operator_dataflows_per_worker
     kind: per_worker
-    description: The same data as `mz_dataflow_operator_dataflows`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_dataflow_operator_dataflows`.
     columns:
     - name: id
       type: uint8
@@ -445,7 +443,7 @@ relations:
   variants:
   - name: mz_dataflow_operator_parents_per_worker
     kind: per_worker
-    description: The same data as `mz_dataflow_operator_parents`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_dataflow_operator_parents`.
     columns:
     - name: id
       type: uint8
@@ -536,7 +534,7 @@ relations:
   variants:
   - name: mz_compute_lir_mapping_per_worker
     kind: per_worker
-    description: The same data as `mz_lir_mapping`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_lir_mapping`.
     columns:
     - name: global_id
       type: text
@@ -577,7 +575,7 @@ relations:
   variants:
   - name: mz_message_counts_per_worker
     kind: per_worker
-    description: The same data as `mz_message_counts`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_message_counts`.
     columns:
     - name: channel_id
       type: uint8
@@ -608,7 +606,7 @@ relations:
   variants:
   - name: mz_peek_durations_histogram_per_worker
     kind: per_worker
-    description: The same data as `mz_peek_durations_histogram`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_peek_durations_histogram`.
     columns:
     - name: worker_id
       type: uint8
@@ -645,7 +643,7 @@ relations:
   variants:
   - name: mz_records_per_dataflow_per_worker
     kind: per_worker
-    description: The same data as `mz_records_per_dataflow`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_records_per_dataflow`.
     columns:
     - name: id
       type: uint8
@@ -693,7 +691,7 @@ relations:
   variants:
   - name: mz_records_per_dataflow_operator_per_worker
     kind: per_worker
-    description: The same data as `mz_records_per_dataflow_operator`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_records_per_dataflow_operator`.
     columns:
     - name: id
       type: uint8
@@ -725,7 +723,7 @@ relations:
   variants:
   - name: mz_scheduling_elapsed_per_worker
     kind: per_worker
-    description: The same data as `mz_scheduling_elapsed`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_scheduling_elapsed`.
     columns:
     - name: id
       type: uint8
@@ -748,7 +746,7 @@ relations:
   variants:
   - name: mz_scheduling_parks_histogram_per_worker
     kind: per_worker
-    description: The same data as `mz_scheduling_parks_histogram`, but reported per Timely Dataflow worker.
+    description: The per-worker data underlying `mz_scheduling_parks_histogram`.
     columns:
     - name: worker_id
       type: uint8

--- a/doc/user/layouts/shortcodes/catalog-relation.html
+++ b/doc/user/layouts/shortcodes/catalog-relation.html
@@ -5,9 +5,9 @@
        name   - relation name (e.g. "mz_active_peeks")
 
      Looks up the relation in .Site.Data.<schema>.relations and renders its
-     description, base column table, and each variant. per_worker variants show
-     the base columns plus their own extra columns; raw variants show only a
-     warning. Type links come from .Site.Data.catalog_types. */}}
+     description, base column table, and each variant. Non-raw variants render
+     their own full column list; raw variants show only a description. Type
+     links come from .Site.Data.catalog_types. */}}
 {{- $schema := .Get "schema" -}}
 {{- $name := .Get "name" -}}
 {{- $types := .Site.Data.catalog_types -}}
@@ -23,7 +23,7 @@
 <h4><code>{{ .name }}</code></h4>
 {{ .description | $.Page.RenderString }}
 {{- if ne .kind "raw" -}}
-{{ template "catalog-relation-table" (dict "columns" (append (index $rel "columns") .columns) "types" $types "Page" $.Page) }}
+{{ template "catalog-relation-variant-table" (dict "columns" .columns "types" $types "Page" $.Page) }}
 {{- end -}}
 {{- end -}}
 {{- end -}}
@@ -37,6 +37,20 @@
 <td><code>{{ .name }}</code></td>
 <td>{{- $u := index $.types .type -}}{{- if $u -}}{{ printf "[`%s`](%s)" .type $u | $.Page.RenderString }}{{- else -}}{{ printf "`%s`" .type | $.Page.RenderString }}{{- end -}}</td>
 <td>{{ .meaning | $.Page.RenderString }}</td>
+</tr>
+{{- end }}
+</tbody>
+</table>
+{{- end -}}
+
+{{- define "catalog-relation-variant-table" -}}
+<table>
+<thead><tr><th>Field</th><th>Type</th></tr></thead>
+<tbody>
+{{- range .columns }}
+<tr>
+<td><code>{{ .name }}</code></td>
+<td>{{- $u := index $.types .type -}}{{- if $u -}}{{ printf "[`%s`](%s)" .type $u | $.Page.RenderString }}{{- else -}}{{ printf "`%s`" .type | $.Page.RenderString }}{{- end -}}</td>
 </tr>
 {{- end }}
 </tbody>

--- a/test/sqllogictest/autogenerated/mz_introspection.slt
+++ b/test/sqllogictest/autogenerated/mz_introspection.slt
@@ -58,6 +58,13 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND ob
 operator_id  uint8  The␠ID␠of␠the␠operator␠that␠created␠the␠arrangement.␠Corresponds␠to␠`mz_dataflow_operators.id`.
 count  bigint  The␠number␠of␠operators␠that␠share␠the␠arrangement.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sharing_per_worker' ORDER BY name
+----
+count  bigint
+operator_id  uint8
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sizes' ORDER BY position
 ----
@@ -68,11 +75,29 @@ size  bigint  The␠utilized␠size␠in␠bytes␠of␠the␠arrangement.
 capacity  bigint  The␠capacity␠in␠bytes␠of␠the␠arrangement.␠Can␠be␠larger␠than␠the␠size.
 allocations  bigint  The␠number␠of␠separate␠memory␠allocations␠backing␠the␠arrangement.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_arrangement_sizes_per_worker' ORDER BY name
+----
+allocations  bigint
+batches  bigint
+capacity  bigint
+operator_id  uint8
+records  bigint
+size  bigint
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_error_counts' ORDER BY position
 ----
 export_id  text  The␠ID␠of␠the␠dataflow␠export.␠Corresponds␠to␠`mz_compute_exports.export_id`.
 count  numeric  The␠count␠of␠errors␠present␠in␠this␠dataflow␠export.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_error_counts_per_worker' ORDER BY name
+----
+count  bigint
+export_id  text
+worker_id  uint8
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_exports' ORDER BY position
@@ -80,11 +105,25 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND ob
 export_id  text  The␠ID␠of␠the␠index,␠materialized␠view,␠or␠subscription␠exported␠by␠the␠dataflow.␠Corresponds␠to␠`mz_catalog.mz_indexes.id`,␠`mz_catalog.mz_materialized_views.id`,␠or␠`mz_internal.mz_subscriptions.id`.
 dataflow_id  uint8  The␠ID␠of␠the␠dataflow.␠Corresponds␠to␠`mz_dataflows.id`.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_exports_per_worker' ORDER BY name
+----
+dataflow_id  uint8
+export_id  text
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_frontiers' ORDER BY position
 ----
 export_id  text  The␠ID␠of␠the␠dataflow␠export.␠Corresponds␠to␠`mz_compute_exports.export_id`.
 time  mz_timestamp  The␠next␠timestamp␠at␠which␠the␠dataflow␠output␠may␠change.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_frontiers_per_worker' ORDER BY name
+----
+export_id  text
+time  mz_timestamp
+worker_id  uint8
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_import_frontiers' ORDER BY position
@@ -93,12 +132,28 @@ export_id  text  The␠ID␠of␠the␠dataflow␠export.␠Corresponds␠to␠`
 import_id  text  The␠ID␠of␠the␠dataflow␠import.␠Corresponds␠to␠`mz_catalog.mz_sources.id`␠or␠`mz_catalog.mz_tables.id`␠or␠`mz_compute_exports.export_id`.
 time  mz_timestamp  The␠next␠timestamp␠at␠which␠the␠dataflow␠input␠may␠change.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_import_frontiers_per_worker' ORDER BY name
+----
+export_id  text
+import_id  text
+time  mz_timestamp
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_operator_durations_histogram' ORDER BY position
 ----
 id  uint8  The␠ID␠of␠the␠operator.␠Corresponds␠to␠`mz_dataflow_operators.id`.
 duration_ns  uint8  The␠upper␠bound␠of␠the␠duration␠bucket␠in␠nanoseconds.
 count  numeric  The␠(noncumulative)␠count␠of␠invocations␠in␠the␠bucket.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_operator_durations_histogram_per_worker' ORDER BY name
+----
+count  bigint
+duration_ns  uint8
+id  uint8
+worker_id  uint8
 
 query TT
 SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_cluster_prometheus_metrics' ORDER BY position
@@ -116,11 +171,25 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND ob
 id  uint8  The␠ID␠of␠the␠dataflow.
 name  text  The␠internal␠name␠of␠the␠dataflow.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflows_per_worker' ORDER BY name
+----
+id  uint8
+name  text
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_addresses' ORDER BY position
 ----
 id  uint8  The␠ID␠of␠the␠channel␠or␠operator.␠Corresponds␠to␠`mz_dataflow_channels.id`␠or␠`mz_dataflow_operators.id`.
 address  list  A␠list␠of␠scope-local␠indexes␠indicating␠the␠path␠from␠the␠root␠to␠this␠channel␠or␠operator.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_addresses_per_worker' ORDER BY name
+----
+address  list
+id  uint8
+worker_id  uint8
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_arrangement_sizes' ORDER BY position
@@ -143,6 +212,17 @@ to_index  uint8  The␠scope-local␠index␠of␠the␠target␠operator.␠Cor
 to_port  uint8  The␠target␠operator's␠input␠port.
 type  text  The␠container␠type␠of␠the␠channel.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_channels_per_worker' ORDER BY name
+----
+from_index  uint8
+from_port  uint8
+id  uint8
+to_index  uint8
+to_port  uint8
+type  text
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_channel_operators' ORDER BY position
 ----
@@ -153,17 +233,42 @@ to_operator_id  uint8  The␠ID␠of␠the␠target␠of␠the␠channel.␠Corr
 to_operator_address  list  The␠address␠of␠the␠target␠of␠the␠channel.␠Corresponds␠to␠`mz_dataflow_addresses.address`.
 type  text  The␠container␠type␠of␠the␠channel.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_channel_operators_per_worker' ORDER BY name
+----
+from_operator_address  list
+from_operator_id  uint8
+id  uint8
+to_operator_address  list
+to_operator_id  uint8
+type  text
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_global_ids' ORDER BY position
 ----
 id  uint8  The␠dataflow␠ID.
 global_id  text  A␠global␠ID␠associated␠with␠that␠dataflow.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_dataflow_global_ids_per_worker' ORDER BY name
+----
+global_id  text
+id  uint8
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_operators' ORDER BY position
 ----
 id  uint8  The␠ID␠of␠the␠operator.
 name  text  The␠internal␠name␠of␠the␠operator.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_operators_per_worker' ORDER BY name
+----
+id  uint8
+name  text
+worker_id  uint8
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_operator_dataflows' ORDER BY position
@@ -173,11 +278,27 @@ name  text  The␠internal␠name␠of␠the␠operator.
 dataflow_id  uint8  The␠ID␠of␠the␠dataflow␠hosting␠the␠operator.␠Corresponds␠to␠`mz_dataflows.id`.
 dataflow_name  text  The␠internal␠name␠of␠the␠dataflow␠hosting␠the␠operator.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_operator_dataflows_per_worker' ORDER BY name
+----
+dataflow_id  uint8
+dataflow_name  text
+id  uint8
+name  text
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_operator_parents' ORDER BY position
 ----
 id  uint8  The␠ID␠of␠the␠operator.␠Corresponds␠to␠`mz_dataflow_operators.id`.
 parent_id  uint8  The␠ID␠of␠the␠operator's␠parent␠operator.␠Corresponds␠to␠`mz_dataflow_operators.id`.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_dataflow_operator_parents_per_worker' ORDER BY name
+----
+id  uint8
+parent_id  uint8
+worker_id  uint8
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_expected_group_size_advice' ORDER BY position
@@ -208,6 +329,18 @@ nesting  uint2  The␠nesting␠level␠of␠this␠LIR␠node.
 operator_id_start  uint8  The␠first␠dataflow␠operator␠ID␠implementing␠this␠LIR␠operator␠(inclusive).
 operator_id_end  uint8  The␠first␠dataflow␠operator␠ID␠_after_␠this␠LIR␠operator␠(exclusive).
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_compute_lir_mapping_per_worker' ORDER BY name
+----
+global_id  text
+lir_id  uint8
+nesting  uint2
+operator  text
+operator_id_end  uint8
+operator_id_start  uint8
+parent_lir_id  uint8
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_message_counts' ORDER BY position
 ----
@@ -217,12 +350,31 @@ received  numeric  The␠number␠of␠messages␠received.
 batch_sent  numeric  The␠number␠of␠batches␠sent.
 batch_received  numeric  The␠number␠of␠batches␠received.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_message_counts_per_worker' ORDER BY name
+----
+batch_received  bigint
+batch_sent  bigint
+channel_id  uint8
+from_worker_id  uint8
+received  bigint
+sent  bigint
+to_worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_peek_durations_histogram' ORDER BY position
 ----
 type  text  The␠peek␠variant:␠`index`␠or␠`persist`.
 duration_ns  uint8  The␠upper␠bound␠of␠the␠bucket␠in␠nanoseconds.
 count  numeric  The␠(noncumulative)␠count␠of␠peeks␠in␠this␠bucket.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_peek_durations_histogram_per_worker' ORDER BY name
+----
+count  bigint
+duration_ns  uint8
+type  text
+worker_id  uint8
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_records_per_dataflow' ORDER BY position
@@ -234,6 +386,18 @@ batches  bigint  The␠number␠of␠batches␠in␠the␠dataflow.
 size  bigint  The␠utilized␠size␠in␠bytes␠of␠the␠arrangements.
 capacity  bigint  The␠capacity␠in␠bytes␠of␠the␠arrangements.␠Can␠be␠larger␠than␠the␠size.
 allocations  bigint  The␠number␠of␠separate␠memory␠allocations␠backing␠the␠arrangements.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_records_per_dataflow_per_worker' ORDER BY name
+----
+allocations  bigint
+batches  bigint
+capacity  bigint
+id  uint8
+name  text
+records  bigint
+size  bigint
+worker_id  uint8
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_records_per_dataflow_operator' ORDER BY position
@@ -247,11 +411,31 @@ size  bigint  The␠utilized␠size␠in␠bytes␠of␠the␠arrangement.
 capacity  bigint  The␠capacity␠in␠bytes␠of␠the␠arrangement.␠Can␠be␠larger␠than␠the␠size.
 allocations  bigint  The␠number␠of␠separate␠memory␠allocations␠backing␠the␠arrangement.
 
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_records_per_dataflow_operator_per_worker' ORDER BY name
+----
+allocations  bigint
+batches  bigint
+capacity  bigint
+dataflow_id  uint8
+id  uint8
+name  text
+records  bigint
+size  bigint
+worker_id  uint8
+
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_scheduling_elapsed' ORDER BY position
 ----
 id  uint8  The␠ID␠of␠the␠operator.␠Corresponds␠to␠`mz_dataflow_operators.id`.
 elapsed_ns  numeric  The␠total␠elapsed␠time␠spent␠in␠the␠operator␠in␠nanoseconds.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_scheduling_elapsed_per_worker' ORDER BY name
+----
+elapsed_ns  bigint
+id  uint8
+worker_id  uint8
 
 query TTT
 SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_scheduling_parks_histogram' ORDER BY position
@@ -259,6 +443,14 @@ SELECT name, type, comment FROM objects WHERE schema = 'mz_introspection' AND ob
 slept_for_ns  uint8  The␠actual␠length␠of␠the␠park␠event␠in␠nanoseconds.
 requested_ns  uint8  The␠requested␠length␠of␠the␠park␠event␠in␠nanoseconds.
 count  numeric  The␠(noncumulative)␠count␠of␠park␠events␠in␠this␠bucket.
+
+query TT
+SELECT name, type FROM objects WHERE schema = 'mz_introspection' AND object = 'mz_scheduling_parks_histogram_per_worker' ORDER BY name
+----
+count  bigint
+requested_ns  uint8
+slept_for_ns  uint8
+worker_id  uint8
 
 query T
 SELECT DISTINCT object FROM objects WHERE schema IN ('mz_introspection') ORDER BY object


### PR DESCRIPTION
### Motivation

Phase 3 of the system-catalog docs data migration.
Stacked on phase 2 (base branch `catalog-docs-data-phase2`); retarget down the stack as earlier phases land.

### Description

Documents the 22 `mz_introspection` `_per_worker` relations whose parent is already documented, by adding each as a `variant` on its parent's YAML entry and removing its `RELATION_SPEC_UNDOCUMENTED` marker.
Refines the variants model: a variant carries its own full column list (name and type) sourced from the catalog, rendered as a 2-column table and lint-checked name-sorted.
This is necessary because an aggregating global view changes column types relative to its per-worker sibling (for example `count` is `numeric` in the global but `bigint` per worker), so a variant cannot reuse the base column types.
Variant columns are extracted from the live catalog, and `bin/sqllogictest` on the regenerated file proves every declared column name and type matches.
Three per-worker relations whose parent is undocumented or lives in `mz_internal` stay as `RELATION_SPEC_UNDOCUMENTED` markers, pending phases 4 and 5.

### Verification

`ci/test/lint-docs-catalog.sh` passes, `bin/sqllogictest` passes on the regenerated `test/sqllogictest/autogenerated/mz_introspection.slt` (54/54), and `hugo` + link checks are clean. The generator has unit tests (`ci/test/test_gen_per_worker_variants.py`).