### PR TITLE
docs: data-driven system-catalog reference, phase 4 (mz_introspection raw variants)

### DIFF
--- a/ci/test/gen-raw-variants.py
+++ b/ci/test/gen-raw-variants.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+"""Adds `raw` variants (existence-only: `{name, kind: raw}`, no columns, no
+description) to documented parent relations, one per `*_raw` differential
+dataflow logging input found in the markdown's `RELATION_SPEC_UNDOCUMENTED`
+markers.
+"""
+
+import re
+
+RAW_MARKER_RE = re.compile(r"RELATION_SPEC_UNDOCUMENTED mz_introspection\.(\w+_raw)\b")
+PARENT_RE = re.compile(r"<!-- RELATION_SPEC \w+\.(\w+) FROM_YAML -->")
+LINKDEF_RE = re.compile(r"^\[[^\]]+\]:\s")
+
+
+def raw_parents(md_text: str) -> list[tuple[str, str]]:
+    """Pair each `*_raw` marker in `md_text` with its nearest preceding
+    documented relation, by scanning line by line.
+
+    A `RELATION_SPEC ... FROM_YAML` line sets the current parent. A
+    reference-link-definition line (`[label]: url`) resets the parent to
+    none: link definitions are conventionally collected in a trailing block
+    at the end of the file, so any `_raw` marker after one belongs to no
+    relation on this page (an orphan) rather than to the last documented one.
+    """
+    parent = None
+    ended = False
+    pairs = []
+    for line in md_text.splitlines():
+        if LINKDEF_RE.match(line):
+            ended = True
+            continue
+        m = PARENT_RE.search(line)
+        if m:
+            parent = m.group(1)
+            continue
+        m = RAW_MARKER_RE.search(line)
+        if m and not ended and parent is not None:
+            pairs.append((m.group(1), parent))
+    return pairs
+
+
+def add_raw_variants(ydoc: dict, md_text: str) -> tuple[dict, str]:
+    """Add a `{name, kind: raw}` variant to each parent relation in `ydoc`
+    for every `*_raw` marker in `md_text`, and strip the corresponding
+    `RELATION_SPEC_UNDOCUMENTED` marker line.
+
+    Raw variants carry no columns and no description: the shortcode renders
+    all of a relation's raw variants together under one grouped warning, so
+    per-variant content would never be shown. Markers with no documented
+    parent on the page (orphans, e.g. a trailing marker after the reference
+    link-definition block) are left in place for a later phase.
+    """
+    relations_by_name = {r["name"]: r for r in ydoc["relations"]}
+
+    for raw_name, parent in raw_parents(md_text):
+        relation = relations_by_name[parent]
+        variants = relation.setdefault("variants", [])
+        if any(v["name"] == raw_name for v in variants):
+            continue
+        variants.append({"name": raw_name, "kind": "raw"})
+        marker = f"<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.{raw_name} -->"
+        marker_re = re.escape(marker)
+        # A marker line sitting alone between two blank lines (the common
+        # case) leaves a doubled blank line if we only drop the marker
+        # itself, so consume one of the surrounding blank lines too. A
+        # marker that instead sits next to sibling markers, with no blank
+        # line between them, is removed on its own: its neighbors already
+        # supply the correct blank-line spacing.
+        md_text = re.sub(
+            rf"(?<=\n)\n{marker_re}\n(?=\n)|{marker_re}\n?",
+            "",
+            md_text,
+        )
+
+    return ydoc, md_text
+
+
+if __name__ == "__main__":
+    import os
+    import sys
+
+    import yaml
+
+    md_path = sys.argv[
+        1
+    ]  # e.g. doc/user/content/reference/system-catalog/mz_introspection.md
+
+    md_text = open(md_path, encoding="utf-8").read()
+
+    schema_name = os.path.splitext(os.path.basename(md_path))[0]
+    data_path = os.path.join("doc", "user", "data", f"{schema_name}.yml")
+    ydoc = yaml.safe_load(open(data_path, encoding="utf-8"))
+
+    ydoc, md_text = add_raw_variants(ydoc, md_text)
+
+    with open(data_path, "w", encoding="utf-8") as f:
+        yaml.safe_dump(ydoc, f, sort_keys=False, allow_unicode=True, width=10_000)
+    with open(md_path, "w", encoding="utf-8") as f:
+        f.write(md_text)
+
+    print(f"updated {data_path} and {md_path}")

--- a/ci/test/test_gen_raw_variants.py
+++ b/ci/test/test_gen_raw_variants.py
@@ -1,0 +1,59 @@
+# Copyright Materialize, Inc. and contributors. All rights reserved.
+#
+# Use of this software is governed by the Business Source License
+# included in the LICENSE file at the root of this repository.
+#
+# As of the Change Date specified in that file, in accordance with
+# the Business Source License, use of this software will be governed
+# by the Apache License, Version 2.0.
+
+import importlib.util
+import pathlib
+
+_spec = importlib.util.spec_from_file_location(
+    "gen_raw_variants",
+    pathlib.Path(__file__).parent / "gen-raw-variants.py",
+)
+gen = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(gen)
+
+MD = (
+    "## `mz_foo`\n\n"
+    "<!-- RELATION_SPEC mz_introspection.mz_foo FROM_YAML -->\n"
+    '{{< catalog-relation schema="mz_introspection" name="mz_foo" >}}\n\n'
+    "<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_foo_raw -->\n"
+    "<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_foo_extra_raw -->\n\n"
+    "## `mz_bar`\n\n"
+    "<!-- RELATION_SPEC mz_introspection.mz_bar FROM_YAML -->\n"
+    '{{< catalog-relation schema="mz_introspection" name="mz_bar" >}}\n\n'
+    "<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_bar_raw -->\n\n"
+    "[`text`]: /sql/types/text\n\n"
+    "<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_orphan_raw -->\n"
+)
+
+
+def test_raw_parents_attributes_and_resets_at_linkdefs():
+    pairs = gen.raw_parents(MD)
+    assert ("mz_foo_raw", "mz_foo") in pairs
+    assert ("mz_foo_extra_raw", "mz_foo") in pairs
+    assert ("mz_bar_raw", "mz_bar") in pairs
+    # Orphan after the link-def block is skipped.
+    assert all(name != "mz_orphan_raw" for name, _ in pairs)
+    assert len(pairs) == 3
+
+
+def test_add_raw_variants_injects_and_removes_markers():
+    ydoc = {
+        "relations": [
+            {"name": "mz_foo", "columns": []},
+            {"name": "mz_bar", "columns": []},
+        ]
+    }
+    ydoc2, md2 = gen.add_raw_variants(ydoc, MD)
+    foo = next(r for r in ydoc2["relations"] if r["name"] == "mz_foo")
+    assert {v["name"] for v in foo["variants"]} == {"mz_foo_raw", "mz_foo_extra_raw"}
+    assert all(v["kind"] == "raw" for v in foo["variants"])
+    assert all("columns" not in v for v in foo["variants"])
+    assert "RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_foo_raw" not in md2
+    # Orphan marker left in place.
+    assert "RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_orphan_raw" in md2

--- a/doc/user/content/reference/system-catalog/mz_introspection.md
+++ b/doc/user/content/reference/system-catalog/mz_introspection.md
@@ -40,29 +40,15 @@ Per-worker relations expose the same data as their global counterparts, but have
 <!-- RELATION_SPEC mz_introspection.mz_arrangement_sharing FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_arrangement_sharing" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_sharing_raw -->
-
 ## `mz_arrangement_sizes`
 
 <!-- RELATION_SPEC mz_introspection.mz_arrangement_sizes FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_arrangement_sizes" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_records_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_batcher_allocations_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_batcher_capacity_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_batcher_records_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_batcher_size_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_batches_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_heap_allocations_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_heap_capacity_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_arrangement_heap_size_raw -->
-
 ## `mz_compute_error_counts`
 
 <!-- RELATION_SPEC mz_introspection.mz_compute_error_counts FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_error_counts" >}}
-
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_error_counts_raw -->
 
 ## `mz_compute_exports`
 
@@ -83,8 +69,6 @@ Per-worker relations expose the same data as their global counterparts, but have
 
 <!-- RELATION_SPEC mz_introspection.mz_compute_operator_durations_histogram FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_compute_operator_durations_histogram" >}}
-
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_compute_operator_durations_histogram_raw -->
 
 ## `mz_cluster_prometheus_metrics`
 
@@ -170,17 +154,10 @@ See [Which part of my query runs slowly or uses a lot of memory?](/transform-dat
 <!-- RELATION_SPEC mz_introspection.mz_message_counts FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_message_counts" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_batch_counts_received_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_batch_counts_sent_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_counts_received_raw -->
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_message_counts_sent_raw -->
-
 ## `mz_peek_durations_histogram`
 
 <!-- RELATION_SPEC mz_introspection.mz_peek_durations_histogram FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_peek_durations_histogram" >}}
-
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_peek_durations_histogram_raw -->
 
 ## `mz_records_per_dataflow`
 
@@ -197,14 +174,10 @@ See [Which part of my query runs slowly or uses a lot of memory?](/transform-dat
 <!-- RELATION_SPEC mz_introspection.mz_scheduling_elapsed FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_scheduling_elapsed" >}}
 
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_elapsed_raw -->
-
 ## `mz_scheduling_parks_histogram`
 
 <!-- RELATION_SPEC mz_introspection.mz_scheduling_parks_histogram FROM_YAML -->
 {{< catalog-relation schema="mz_introspection" name="mz_scheduling_parks_histogram" >}}
-
-<!-- RELATION_SPEC_UNDOCUMENTED mz_introspection.mz_scheduling_parks_histogram_raw -->
 
 [`bigint`]: /sql/types/bigint
 [`bigint list`]: /sql/types/list

--- a/doc/user/data/mz_introspection.yml
+++ b/doc/user/data/mz_introspection.yml
@@ -51,6 +51,8 @@ relations:
       type: uint8
     - name: count
       type: bigint
+  - name: mz_arrangement_sharing_raw
+    kind: raw
 - name: mz_arrangement_sizes
   description: 'The `mz_arrangement_sizes` view describes the size of each [arrangement](/get-started/arrangements/#arrangements) in the system.
 
@@ -96,6 +98,24 @@ relations:
       type: bigint
     - name: allocations
       type: bigint
+  - name: mz_arrangement_records_raw
+    kind: raw
+  - name: mz_arrangement_batcher_allocations_raw
+    kind: raw
+  - name: mz_arrangement_batcher_capacity_raw
+    kind: raw
+  - name: mz_arrangement_batcher_records_raw
+    kind: raw
+  - name: mz_arrangement_batcher_size_raw
+    kind: raw
+  - name: mz_arrangement_batches_raw
+    kind: raw
+  - name: mz_arrangement_heap_allocations_raw
+    kind: raw
+  - name: mz_arrangement_heap_capacity_raw
+    kind: raw
+  - name: mz_arrangement_heap_size_raw
+    kind: raw
 - name: mz_compute_error_counts
   description: 'The `mz_compute_error_counts` view describes the counts of errors in objects exported by [dataflows](/get-started/arrangements/#dataflows) in the system.
 
@@ -119,6 +139,8 @@ relations:
       type: uint8
     - name: count
       type: bigint
+  - name: mz_compute_error_counts_raw
+    kind: raw
 - name: mz_compute_exports
   description: The `mz_compute_exports` view describes the objects exported by [dataflows](/get-started/arrangements/#dataflows) in the system.
   columns:
@@ -213,6 +235,8 @@ relations:
       type: uint8
     - name: count
       type: bigint
+  - name: mz_compute_operator_durations_histogram_raw
+    kind: raw
 - name: mz_dataflows
   description: The `mz_dataflows` view describes the [dataflows](/get-started/arrangements/#dataflows) in the system.
   columns:
@@ -591,6 +615,14 @@ relations:
       type: bigint
     - name: batch_received
       type: bigint
+  - name: mz_message_batch_counts_received_raw
+    kind: raw
+  - name: mz_message_batch_counts_sent_raw
+    kind: raw
+  - name: mz_message_counts_received_raw
+    kind: raw
+  - name: mz_message_counts_sent_raw
+    kind: raw
 - name: mz_peek_durations_histogram
   description: The `mz_peek_durations_histogram` view describes a histogram of the duration in nanoseconds of read queries ("peeks") in the [dataflow](/get-started/arrangements/#dataflows) layer.
   columns:
@@ -616,6 +648,8 @@ relations:
       type: uint8
     - name: count
       type: bigint
+  - name: mz_peek_durations_histogram_raw
+    kind: raw
 - name: mz_records_per_dataflow
   description: The `mz_records_per_dataflow` view describes the number of records in each [dataflow](/get-started/arrangements/#dataflows).
   columns:
@@ -731,6 +765,8 @@ relations:
       type: uint8
     - name: elapsed_ns
       type: bigint
+  - name: mz_scheduling_elapsed_raw
+    kind: raw
 - name: mz_scheduling_parks_histogram
   description: The `mz_scheduling_parks_histogram` view describes a histogram of [dataflow](/get-started/arrangements/#dataflows) worker park events. A park event occurs when a worker has no outstanding work.
   columns:
@@ -756,3 +792,5 @@ relations:
       type: uint8
     - name: count
       type: bigint
+  - name: mz_scheduling_parks_histogram_raw
+    kind: raw

--- a/doc/user/layouts/shortcodes/catalog-relation.html
+++ b/doc/user/layouts/shortcodes/catalog-relation.html
@@ -6,7 +6,8 @@
 
      Looks up the relation in .Site.Data.<schema>.relations and renders its
      description, base column table, and each variant. Non-raw variants render
-     their own full column list; raw variants show only a description. Type
+     their own heading, description, and full column list; raw variants are
+     grouped into a single "Raw relations" section with a shared warning. Type
      links come from .Site.Data.catalog_types. */}}
 {{- $schema := .Get "schema" -}}
 {{- $name := .Get "name" -}}
@@ -19,12 +20,24 @@
 {{- with $rel -}}
 {{ .description | $.Page.RenderString }}
 {{ template "catalog-relation-table" (dict "columns" .columns "types" $types "Page" $.Page) }}
+{{- $raws := slice -}}
 {{- range .variants -}}
+{{- if eq .kind "raw" -}}
+{{- $raws = $raws | append . -}}
+{{- else -}}
 <h4><code>{{ .name }}</code></h4>
 {{ .description | $.Page.RenderString }}
-{{- if ne .kind "raw" -}}
 {{ template "catalog-relation-variant-table" (dict "columns" .columns "types" $types "Page" $.Page) }}
 {{- end -}}
+{{- end -}}
+{{- if $raws -}}
+<h4>Raw relations</h4>
+<p>These relations expose raw differential dataflow data, where the number of rows and their diffs carry the meaning. They back the relation above and are not intended to be queried directly.</p>
+<ul>
+{{- range $raws }}
+<li><code>{{ .name }}</code></li>
+{{- end }}
+</ul>
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
### Motivation

Phase 4 of the system-catalog docs data migration.
Stacked on phase 3 (base branch `catalog-docs-data-phase3`).

### Description

Acknowledges the 19 `mz_introspection` `_raw` relations (internal differential-dataflow logging inputs) as `raw` variants on their parent's YAML entry, removing their `RELATION_SPEC_UNDOCUMENTED` markers.
A raw variant is name-plus-kind only, with no column table; the shortcode groups a relation's raw siblings into one "Raw relations" warning section (for example the nine raw inputs under `mz_arrangement_sizes`).
Lint treats raw variants as existence-only, so this is a pure move: the generated `test/sqllogictest/autogenerated/mz_introspection.slt` is unchanged.
Each raw relation's parent is the documented section it sits under in the markdown, resolved with a generator that resets attribution at the reference-link-definition block so the trailing orphan cluster is not misattributed.

`mz_dataflow_operator_reachability` (and its per-worker/raw siblings) and two orphan per-worker relations whose parents live in `mz_internal` stay as `RELATION_SPEC_UNDOCUMENTED`, pending phase 5 and subject-matter input.

### Verification

`ci/test/lint-docs-catalog.sh` reports zero diff (pure-move proof), `bin/sqllogictest` passes, and the two-build `hugo` + `htmltest` gate is clean (895 documents, 0 errors). The generator has unit tests (`ci/test/test_gen_raw_variants.py`).